### PR TITLE
feat: 프로젝트 layout 구성 (#25)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -3,7 +3,7 @@
   <div class="min-h-screen bg-gray-100 flex items-center justify-center">
     <div id="app" class="w-[393px] h-[852px] bg-white shadow-md overflow-hidden relative">
       <!-- TODO: 앱 레이아웃 구현 -->
-      <MainHeader></MainHeader>
+      <component :is="layoutHeader" />
       <RouterView></RouterView>
       <NavBar></NavBar>
     </div>
@@ -13,8 +13,20 @@
 <script setup>
 // TODO: 앱 로직 구현
 import { RouterView } from "vue-router";
+import { computed } from "vue";
+import { useRoute } from "vue-router";
 import MainHeader from "./components/common/MainHeader.vue";
 import NavBar from "./components/common/NavBar.vue";
+import OnboardingHeader from "@/components/common/OnboardingHeader.vue";
+
+const route = useRoute();
+
+const layoutHeader = computed(() => {
+  const layout = route.meta.layout;
+  if (layout === "onboardHeader") return OnboardingHeader;
+  if (layout === "noHeader") return null;
+  return MainHeader;
+});
 </script>
 
 <style>

--- a/src/components/common/CardContainer.vue
+++ b/src/components/common/CardContainer.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     class="absolute left-0 right-0 w-full bg-white rounded-t-3xl rounded-b-3xl shadow-lg px-6 pt-12 pb-8 flex flex-col justify-start items-center z-10"
-    style="top: 108px; height: calc(100vh - 108px)"
+    style="top: 108px; height: calc(100%)"
   >
     <slot />
   </div>

--- a/src/components/common/NavBar.vue
+++ b/src/components/common/NavBar.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="bg-white rounded-t-2xl shadow-lg h-16 w-[393px] absolute left-0 top-[789px]">
+  <div class="bg-white rounded-t-2xl shadow-lg h-16 w-[393px] absolute left-0 top-[789px] z-11">
     <div class="flex justify-around items-center h-full px-4">
       <!-- Home Button (Active) -->
       <div class="flex flex-col items-center">

--- a/src/components/common/OnboardingHeader.vue
+++ b/src/components/common/OnboardingHeader.vue
@@ -13,8 +13,4 @@
 // 필요시 추가 로직 작성
 </script>
 
-<style scoped>
-header {
-  /* 상단 고정, 배경 등 필요시 스타일 추가 */
-}
-</style>
+<style scoped></style>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -28,28 +28,33 @@ const router = createRouter({
     },
     {
       path: "/investment-survey",
-      name: "InvestmentSurvey",
+      name: "investmentSurvey",
       component: InvestmentSurveyView,
+      meta: { layout: "onboardHeader" },
     },
     {
       path: "/investment-survey/result",
-      name: "InvestmentSurveyResult",
+      name: "investmentSurveyResult",
       component: InvestmentSurveyResult,
+      meta: { layout: "noHeader" },
     },
     {
       path: "/bank-select",
       name: "bankSelect",
       component: BankSelectView,
+      meta: { layout: "noHeader" },
     },
     {
       path: "/bank-login",
       name: "bankLogin",
       component: BankLoginView,
+      meta: { layout: "noHeader" },
     },
     {
       path: "/bank-linking-success",
       name: "bankLinkingSuccess",
       component: BankLinkingSuccessView,
+      meta: { layout: "noHeader" },
     },
     {
       path: "/recommend",
@@ -65,10 +70,11 @@ const router = createRouter({
       path: "/login",
       name: "login",
       component: LoginPage,
+      meta: { layout: "noHeader" },
     },
     {
       path: "/goal/edit",
-      name: "GoalEditView",
+      name: "goalEditView",
       component: GoalEditView,
     },
 

--- a/src/views/onBoarding/InvestmentSurveyView.vue
+++ b/src/views/onBoarding/InvestmentSurveyView.vue
@@ -1,66 +1,55 @@
 <template>
-  <div class="min-h-screen bg-gradient-to-b from-[#2D2363] to-white flex flex-col relative">
-    <OnboardingHeader />
-    <div class="flex-1 flex flex-col items-center">
-      <!-- 설문 카드 -->
-      <CardContainer>
-        <template v-if="!showResult">
-          <!-- Progress Bar -->
-          <div class="w-full mb-6">
-            <div class="flex justify-between items-center mb-2">
-              <span class="text-xs text-gray-400">진행률</span>
-              <span class="text-xs text-gray-400">{{ currentIndex + 1 }}/{{ questions.length }}</span>
-            </div>
-            <div class="w-full bg-gray-200 rounded-full h-2.5">
-              <div
-                class="bg-[#4B3C8A] h-2.5 rounded-full"
-                :style="{ width: ((currentIndex + 1) / questions.length) * 100 + '%' }"
-              ></div>
-            </div>
-          </div>
-          <!-- 질문 -->
-          <div class="mb-6 font-bold text-gray-800 text-base w-full">
-            {{ questions[currentIndex].question }}
-          </div>
-          <!-- 체크리스트 -->
-          <form class="w-full">
-            <div class="flex flex-col gap-3 text-sm text-gray-700">
-              <label
-                v-for="(choice, idx) in questions[currentIndex].choices"
-                :key="idx"
-                class="flex items-center gap-2"
-              >
-                <input type="radio" :name="'q' + currentIndex" :value="idx" v-model="selected" />
-                {{ choice.text }}
-              </label>
-            </div>
-          </form>
-          <!-- 다음/완료 버튼 -->
-          <button
-            class="w-full py-3 rounded-lg text-white font-semibold bg-[#B9AFFF] shadow-md disabled:bg-[#B9AFFF]/50 transition mt-8"
-            :disabled="selected === null"
-            @click="nextOrFinish"
-          >
-            {{ currentIndex === questions.length - 1 ? "완료" : "다음" }}
-          </button>
-        </template>
-        <template v-else>
-          <div class="w-full flex flex-col items-center justify-center h-full">
-            <div class="text-lg font-bold mb-4">당신의 투자 성향은?</div>
-            <div class="text-2xl font-extrabold text-[#4B3C8A] mb-2">{{ resultType }}</div>
-            <div class="text-gray-700">가장 높은 점수를 받은 성향입니다.</div>
-            <button class="mt-8 text-[#4B3C8A] underline" @click="resetSurvey">다시하기</button>
-          </div>
-        </template>
-      </CardContainer>
-    </div>
-  </div>
+  <CardContainer>
+    <template v-if="!showResult">
+      <!-- Progress Bar -->
+      <div class="w-full mb-6">
+        <div class="flex justify-between items-center mb-2">
+          <span class="text-xs text-gray-400">진행률</span>
+          <span class="text-xs text-gray-400">{{ currentIndex + 1 }}/{{ questions.length }}</span>
+        </div>
+        <div class="w-full bg-gray-200 rounded-full h-2.5">
+          <div
+            class="bg-[#4B3C8A] h-2.5 rounded-full"
+            :style="{ width: ((currentIndex + 1) / questions.length) * 100 + '%' }"
+          ></div>
+        </div>
+      </div>
+      <!-- 질문 -->
+      <div class="mb-6 font-bold text-gray-800 text-base w-full">
+        {{ questions[currentIndex].question }}
+      </div>
+      <!-- 체크리스트 -->
+      <form class="w-full">
+        <div class="flex flex-col gap-3 text-sm text-gray-700">
+          <label v-for="(choice, idx) in questions[currentIndex].choices" :key="idx" class="flex items-center gap-2">
+            <input type="radio" :name="'q' + currentIndex" :value="idx" v-model="selected" />
+            {{ choice.text }}
+          </label>
+        </div>
+      </form>
+      <!-- 다음/완료 버튼 -->
+      <button
+        class="w-full py-3 rounded-lg text-white font-semibold bg-[#B9AFFF] shadow-md disabled:bg-[#B9AFFF]/50 transition mt-8"
+        :disabled="selected === null"
+        @click="nextOrFinish"
+      >
+        {{ currentIndex === questions.length - 1 ? "완료" : "다음" }}
+      </button>
+    </template>
+    <template v-else>
+      <div class="w-full flex flex-col items-center justify-center h-full">
+        <div class="text-lg font-bold mb-4">당신의 투자 성향은?</div>
+        <div class="text-2xl font-extrabold text-[#4B3C8A] mb-2">{{ resultType }}</div>
+        <div class="text-gray-700">가장 높은 점수를 받은 성향입니다.</div>
+        <button class="mt-8 text-[#4B3C8A] underline" @click="resetSurvey">다시하기</button>
+      </div>
+    </template>
+  </CardContainer>
 </template>
 
 <script setup>
 import { ref, computed, watch } from "vue";
 import { useRouter } from "vue-router";
-import OnboardingHeader from "@/components/common/OnboardingHeader.vue";
 import CardContainer from "@/components/common/CardContainer.vue";
 
 const types = ["안전형", "안정추구형", "위험중립형", "적극투자형", "공격투자형"];


### PR DESCRIPTION
페이지에 맞게  header 나오 수 있도록 app.vue수정

## 🔖 PR 유형
- [ ] ✨ 기능 추가
- [ ] 🐛 버그 수정
- [ ] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요
페이지마다 다른 헤더 적용 로직 구현
## 🔧 작업 내용
- vue-router의 `meta.layout` 값을 활용해 페이지별로 다른 헤더를 동적으로 렌더링하도록 수정
- `App.vue`에서 `layoutHeader` computed 속성을 통해 조건 분기
- 공통 헤더 컴포넌트는 `MainHeader.vue`, `OnboardHeader.vue` 등으로 분리
- 헤더가 필요 없는 페이지(`login` 등)는 `meta.layout = "none"` 설정하여 헤더 미출력
- 
## ✅ 체크리스트
- [ ] 테스트 완료(Postman, Swagger)

## 📝 기타 참고 사항
- 주의할 점, 추후 리팩토링 필요성 등

## 📎 관련 이슈
Close #25 