### PR TITLE
fix: 페이지마다 네비게이션바 위치 불일치

### DIFF
--- a/src/components/common/MainHeader.vue
+++ b/src/components/common/MainHeader.vue
@@ -17,25 +17,7 @@
           <span class="text-white text-sm mt-1 ml-1 drop-shadow">스마트한 자산 관리</span>
         </div>
         <div class="flex items-center space-x-4 mt-2">
-          <!-- 돋보기 아이콘
-          <button aria-label="검색" class="text-white hover:text-gray-200 cursor-pointer">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke-width="1.5"
-              stroke="currentColor"
-              class="w-6 h-6"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z"
-              />
-            </svg>
-          </button> -->
-          <!-- 알림 아이콘 -->
-          <button aria-label="알림" class="text-white hover:text-gray-200 cursor-pointer" @click="navigateTo('/alarm')">
+          <button aria-label="알림" class="text-white hover:text-gray-200 cursor-pointer">
             <svg
               xmlns="http://www.w3.org/2000/svg"
               fill="none"

--- a/src/components/layouts/DefaultLayout.vue
+++ b/src/components/layouts/DefaultLayout.vue
@@ -8,7 +8,7 @@
     >
       <slot />
     </div>
-    <NavBar class="flex-shrink-0 relative z-30" />
+    <NavBar class="sticky bottom-0 bg-white z-10" />
   </div>
 </template>
 

--- a/src/components/layouts/MainLayout.vue
+++ b/src/components/layouts/MainLayout.vue
@@ -3,12 +3,12 @@
     <MainHeader class="flex-shrink-0 relative z-10" />
     <div
       id="content"
-      class="w-full bg-white rounded-t-3xl shadow-lg px-6 pt-12 pb-8 -mt-[84px] overflow-y-auto"
+      class="w-full bg-white rounded-t-3xl shadow-lg px-6 pt-12 pb-8 z-* -mt-[84px] overflow-y-auto"
       :style="{ maxHeight: 'calc(852px - 148px)', minHeight: 'calc(852px - 148px)' }"
     >
       <slot />
     </div>
-    <NavBar class="flex-shrink-0 relative z-30" />
+    <NavBar class="sticky bottom-0 bg-white z-10" />
   </div>
 </template>
 

--- a/src/components/layouts/NavBarLayout.vue
+++ b/src/components/layouts/NavBarLayout.vue
@@ -1,10 +1,12 @@
 <template>
-  <div class="h-full flex flex-col">
-    <div class="flex-1">
+  <div class="h-screen flex flex-col">
+    <!-- 메인 콘텐츠: 스크롤 가능 -->
+    <div class="flex-1 overflow-y-auto">
       <slot></slot>
     </div>
 
-    <NavBar class="flex-shrink-0" />
+    <!-- NavBar: 하단 고정 -->
+    <NavBar class="sticky bottom-0 bg-white z-10" />
   </div>
 </template>
 

--- a/src/views/MainView.vue
+++ b/src/views/MainView.vue
@@ -1,327 +1,41 @@
 <template>
-  <div class="w-full h-full flex flex-col relative">
-    <!-- 스크롤 가능한 전체 컨텐츠 -->
-    <div class="flex-1 overflow-y-auto overflow-x-hidden">
-      <!-- 헤더 영역 -->
-      <MainHeader class="relative z-10" />
+  <MainLayout>
+    <div class="w-full h-full flex flex-col relative">
+      <!-- 스크롤 가능한 전체 컨텐츠 -->
+      <div class="flex-1 overflow-y-auto overflow-x-hidden">
+        <!-- 헤더 영역 -->
 
-      <!-- 메인 컨텐츠 영역 -->
-      <div class="bg-transparent -mt-[100px] relative z-20 pb-20">
-        <div class="px-6 pt-12 pb-4">
-          <div class="flex flex-col items-center">
-            <!-- 전체 자산 카드 -->
-            <div
-              class="h-[200px] w-[calc(100%-8px)] max-w-[500px] bg-white rounded-2xl shadow-lg p-5 flex items-center justify-around -mt-[7px] mb-6 relative z-20"
-            >
-              <div class="flex flex-col justify-center items-start w-auto h-[132px] mr-4 pr-4 flex-shrink-0 min-w-0">
-                <div class="text-black text-base font-semibold mb-1 text-left whitespace-nowrap">전체 자산</div>
-                <div class="text-gray-600 text-sm mb-1 text-left whitespace-nowrap">총 7개 계좌 관리 중</div>
-                <div class="text-black text-2xl font-bold mb-1 text-left whitespace-nowrap">3,015,000원</div>
-                <div class="text-green-600 text-xs text-left whitespace-nowrap">전월 대비 +12.5%</div>
-              </div>
-              <div class="ml-6 w-56 h-56 flex items-center justify-center">
-                <v-chart class="w-full h-full" :option="chartOption" autoresize />
-              </div>
-            </div>
-
-            <!-- 목표 슬라이더 카드 -->
-            <div
-              class="h-[220px] w-[calc(100%-16px)] max-w-[380px] mb-6 bg-white rounded-2xl shadow-lg p-4 relative overflow-hidden"
-            >
-              <div class="flex items-center justify-between mb-4">
-                <router-link
-                  to="/goal/detail"
-                  class="flex items-center text-black text-sm font-semibold hover:text-indigo-600 transition-colors"
-                >
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    class="h-4 w-4 mr-2 text-indigo-600"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                  >
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z"
-                    />
-                  </svg>
-                  나의 목표
-                </router-link>
-
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  class="h-4 w-4 text-gray-600"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                >
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"
-                  />
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
-                  />
-                </svg>
-              </div>
-
-              <div class="goals-slider absolute top-[38px] left-0 w-full h-[171px] overflow-hidden">
-                <div
-                  class="flex transition-transform duration-300 ease-in-out h-full"
-                  :style="{ transform: `translateX(-${currentSlide * 100}%)` }"
-                >
-                  <!-- 첫 번째 목표 카드 -->
-                  <div class="min-w-full h-full flex">
-                    <div class="w-full h-[170px] bg-white p-4 relative">
-                      <div class="absolute left-4 top-4 w-[250px] h-[117px]">
-                        <div class="flex items-center text-black text-xs font-semibold">
-                          <svg
-                            xmlns="http://www.w3.org/2000/svg"
-                            class="h-4 w-4 mr-2 text-blue-600"
-                            fill="none"
-                            viewBox="0 0 24 24"
-                            stroke="currentColor"
-                          >
-                            <path
-                              stroke-linecap="round"
-                              stroke-linejoin="round"
-                              stroke-width="2"
-                              d="M19 14l-7 7m0 0l-7-7m7 7V3"
-                            />
-                          </svg>
-                          자가용 구매하기
-                        </div>
-                      </div>
-
-                      <div class="absolute right-4 top-6">
-                        <div class="bg-green-500 rounded-full h-5 px-3 flex items-center justify-center">
-                          <span class="text-white text-xs font-semibold">목표 달성 !</span>
-                        </div>
-                      </div>
-
-                      <div class="absolute left-4 top-18 flex flex-wrap gap-1 text-xs">
-                        <div class="flex items-center">
-                          <div class="w-2 h-2 rounded-sm mr-1 bg-green-500"></div>
-                          <span class="text-gray-600">주거래 60%</span>
-                        </div>
-                        <div class="flex items-center">
-                          <div class="w-2 h-2 rounded-sm mr-1 bg-green-600"></div>
-                          <span class="text-gray-600">적금 40%</span>
-                        </div>
-                      </div>
-
-                      <div class="absolute left-4 bottom-16 w-[calc(100%-32px)] h-3">
-                        <div class="bg-gray-300 rounded-full h-3 w-full relative overflow-hidden">
-                          <div class="bg-green-500 h-3 rounded-l-full absolute left-0" style="width: 60%"></div>
-                          <div class="bg-green-600 h-3 rounded-r-full absolute" style="width: 40%; left: 60%"></div>
-                        </div>
-                      </div>
-
-                      <div class="bg-green-50 rounded-lg h-10 w-[calc(100%-32px)] absolute left-4 bottom-4 p-2">
-                        <div class="text-green-800 text-xs font-bold">예상 달성일: 2025-12-28</div>
-                        <div class="text-green-600 text-xs">목표보다 199일 빠름</div>
-                      </div>
-                    </div>
-                  </div>
-
-                  <!-- 두 번째 목표 카드 -->
-                  <div class="min-w-full h-full flex">
-                    <div class="w-full h-[170px] bg-white p-4 relative">
-                      <div class="absolute left-4 top-4 w-[250px]">
-                        <div class="flex items-center text-black text-xs font-semibold">
-                          <svg
-                            xmlns="http://www.w3.org/2000/svg"
-                            class="h-4 w-4 mr-2 text-blue-600"
-                            fill="none"
-                            viewBox="0 0 24 24"
-                            stroke="currentColor"
-                          >
-                            <path
-                              stroke-linecap="round"
-                              stroke-linejoin="round"
-                              stroke-width="2"
-                              d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8"
-                            />
-                          </svg>
-                          유럽 여행 자금
-                        </div>
-                        <div class="text-blue-600 text-xs mt-2 font-medium">진행 중 (75%)</div>
-                      </div>
-
-                      <div class="absolute right-4 top-6">
-                        <div class="bg-blue-500 rounded-full h-5 px-3 flex items-center justify-center">
-                          <span class="text-white text-xs font-semibold">75%</span>
-                        </div>
-                      </div>
-
-                      <div class="absolute left-4 top-18 flex flex-wrap gap-1 text-xs">
-                        <div class="flex items-center">
-                          <div class="w-2 h-2 rounded-sm mr-1 bg-blue-500"></div>
-                          <span class="text-gray-600">주거래 40%</span>
-                        </div>
-                        <div class="flex items-center">
-                          <div class="w-2 h-2 rounded-sm mr-1 bg-cyan-500"></div>
-                          <span class="text-gray-600">적금 25%</span>
-                        </div>
-                        <div class="flex items-center">
-                          <div class="w-2 h-2 rounded-sm mr-1 bg-purple-500"></div>
-                          <span class="text-gray-600">투자 10%</span>
-                        </div>
-                      </div>
-
-                      <div class="absolute left-4 bottom-16 w-[calc(100%-32px)] h-3">
-                        <div class="bg-gray-300 rounded-full h-3 w-full relative overflow-hidden">
-                          <div class="bg-blue-500 h-3 absolute left-0" style="width: 40%"></div>
-                          <div class="bg-cyan-500 h-3 absolute" style="width: 25%; left: 40%"></div>
-                          <div class="bg-purple-500 h-3 absolute" style="width: 10%; left: 65%"></div>
-                        </div>
-                      </div>
-
-                      <div class="bg-blue-50 rounded-lg h-10 w-[calc(100%-32px)] absolute left-4 bottom-2 p-2">
-                        <div class="text-blue-800 text-xs font-bold">예상 달성일: 2025-08-20</div>
-                        <div class="text-blue-600 text-xs">1,500,000원 / 2,000,000원</div>
-                      </div>
-                    </div>
-                  </div>
-
-                  <!-- 세 번째 목표 카드 -->
-                  <div class="min-w-full h-full flex">
-                    <div class="w-full h-[170px] bg-white p-4 relative">
-                      <div class="absolute left-4 top-4 w-[250px]">
-                        <div class="flex items-center text-black text-xs font-semibold">
-                          <svg
-                            xmlns="http://www.w3.org/2000/svg"
-                            class="h-4 w-4 mr-2 text-green-600"
-                            fill="none"
-                            viewBox="0 0 24 24"
-                            stroke="currentColor"
-                          >
-                            <path
-                              stroke-linecap="round"
-                              stroke-linejoin="round"
-                              stroke-width="2"
-                              d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1"
-                            />
-                          </svg>
-                          비상 자금 마련
-                        </div>
-                        <div class="text-orange-600 text-xs mt-2 font-medium">진행 중 (45%)</div>
-                      </div>
-
-                      <div class="absolute right-4 top-6">
-                        <div class="bg-orange-500 rounded-full h-5 px-3 flex items-center justify-center">
-                          <span class="text-white text-xs font-semibold">45%</span>
-                        </div>
-                      </div>
-
-                      <div class="absolute left-4 top-18 flex flex-wrap gap-1 text-xs">
-                        <div class="flex items-center">
-                          <div class="w-2 h-2 rounded-sm mr-1 bg-orange-500"></div>
-                          <span class="text-gray-600">비상금 30%</span>
-                        </div>
-                        <div class="flex items-center">
-                          <div class="w-2 h-2 rounded-sm mr-1 bg-yellow-500"></div>
-                          <span class="text-gray-600">예금 15%</span>
-                        </div>
-                      </div>
-
-                      <div class="absolute left-4 bottom-16 w-[calc(100%-32px)] h-3">
-                        <div class="bg-gray-300 rounded-full h-3 w-full relative overflow-hidden">
-                          <div class="bg-orange-500 h-3 absolute left-0" style="width: 30%"></div>
-                          <div class="bg-yellow-500 h-3 absolute" style="width: 15%; left: 30%"></div>
-                        </div>
-                      </div>
-
-                      <div class="bg-orange-50 rounded-lg h-10 w-[calc(100%-32px)] absolute left-4 bottom-2 p-2">
-                        <div class="text-orange-800 text-xs font-bold">예상 달성일: 2026-03-15</div>
-                        <div class="text-orange-600 text-xs">4,500,000원 / 10,000,000원</div>
-                      </div>
-                    </div>
-                  </div>
-
-                  <!-- 목표 추가 버튼 -->
-                  <div class="min-w-full h-full flex">
-                    <button
-                      class="w-full h-[170px] bg-white border-2 border-dashed border-gray-300 hover:border-indigo-400 hover:bg-indigo-50 transition-colors duration-200 flex flex-col items-center justify-center group"
-                    >
-                      <div
-                        class="w-12 h-12 rounded-full bg-gray-100 group-hover:bg-indigo-100 flex items-center justify-center mb-3 transition-colors duration-200"
-                      >
-                        <svg
-                          xmlns="http://www.w3.org/2000/svg"
-                          class="h-6 w-6 text-gray-400 group-hover:text-indigo-600 transition-colors duration-200"
-                          fill="none"
-                          viewBox="0 0 24 24"
-                          stroke="currentColor"
-                        >
-                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
-                        </svg>
-                      </div>
-
-                      <div class="text-center">
-                        <p
-                          class="text-gray-600 group-hover:text-indigo-600 text-sm font-medium transition-colors duration-200"
-                        >
-                          새 목표 추가
-                        </p>
-                        <p
-                          class="text-gray-400 group-hover:text-indigo-400 text-xs mt-1 transition-colors duration-200"
-                        >
-                          목표를 설정하고 달성해보세요
-                        </p>
-                      </div>
-                    </button>
-                  </div>
+        <!-- 메인 컨텐츠 영역 -->
+        <div class="bg-transparent -mt-[100px] relative z-20 pb-20">
+          <div class="px-6 pt-12 pb-4">
+            <div class="flex flex-col items-center">
+              <!-- 전체 자산 카드 -->
+              <div
+                class="h-[200px] w-[calc(100%-8px)] max-w-[500px] bg-white rounded-2xl shadow-lg p-5 flex items-center justify-around -mt-[7px] mb-6 relative z-20"
+              >
+                <div class="flex flex-col justify-center items-start w-auto h-[132px] mr-4 pr-4 flex-shrink-0 min-w-0">
+                  <div class="text-black text-base font-semibold mb-1 text-left whitespace-nowrap">전체 자산</div>
+                  <div class="text-gray-600 text-sm mb-1 text-left whitespace-nowrap">총 7개 계좌 관리 중</div>
+                  <div class="text-black text-2xl font-bold mb-1 text-left whitespace-nowrap">3,015,000원</div>
+                  <div class="text-green-600 text-xs text-left whitespace-nowrap">전월 대비 +12.5%</div>
+                </div>
+                <div class="ml-6 w-56 h-56 flex items-center justify-center">
+                  <v-chart class="w-full h-full" :option="chartOption" autoresize />
                 </div>
               </div>
 
-              <!-- Slide Indicators -->
-              <div class="absolute bottom-2 left-1/2 transform -translate-x-1/2 flex space-x-2">
-                <button
-                  v-for="(slide, index) in 4"
-                  :key="index"
-                  @click="currentSlide = index"
-                  :class="[
-                    'w-2 h-2 rounded-full transition-colors',
-                    currentSlide === index ? 'bg-indigo-600' : 'bg-gray-300',
-                  ]"
-                ></button>
-              </div>
-
-              <!-- Navigation Arrows -->
-              <button
-                v-if="currentSlide > 0"
-                @click="previousSlide"
-                class="absolute left-2 top-1/2 transform -translate-y-1/2 bg-white rounded-full w-8 h-8 flex items-center justify-center shadow-lg hover:bg-gray-50 transition-colors z-20"
+              <!-- 목표 슬라이더 카드 -->
+              <div
+                class="h-[220px] w-[calc(100%-16px)] max-w-[380px] mb-6 bg-white rounded-2xl shadow-lg p-4 relative overflow-hidden"
               >
-                <span class="text-gray-600">‹</span>
-              </button>
-
-              <button
-                v-if="currentSlide < 3"
-                @click="nextSlide"
-                class="absolute right-2 top-1/2 transform -translate-y-1/2 bg-white rounded-full w-8 h-8 flex items-center justify-center shadow-lg hover:bg-gray-50 transition-colors z-20"
-              >
-                <span class="text-gray-600">›</span>
-              </button>
-            </div>
-
-            <!-- Investment Status Section -->
-            <div class="h-auto w-[calc(100%-16px)] max-w-[380px] bg-white rounded-2xl shadow-lg p-5">
-              <!-- Header -->
-              <div class="flex justify-between items-center mb-2">
-                <div class="flex items-center">
-                  <div class="text-indigo-600 mr-2">
+                <div class="flex items-center justify-between mb-4">
+                  <router-link
+                    to="/goal/detail"
+                    class="flex items-center text-black text-sm font-semibold hover:text-indigo-600 transition-colors"
+                  >
                     <svg
                       xmlns="http://www.w3.org/2000/svg"
-                      class="h-5 w-5"
+                      class="h-4 w-4 mr-2 text-indigo-600"
                       fill="none"
                       viewBox="0 0 24 24"
                       stroke="currentColor"
@@ -330,115 +44,405 @@
                         stroke-linecap="round"
                         stroke-linejoin="round"
                         stroke-width="2"
-                        d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6"
+                        d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z"
                       />
                     </svg>
+                    나의 목표
+                  </router-link>
+
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    class="h-4 w-4 text-gray-600"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                  >
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"
+                    />
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+                    />
+                  </svg>
+                </div>
+
+                <div class="goals-slider absolute top-[38px] left-0 w-full h-[171px] overflow-hidden">
+                  <div
+                    class="flex transition-transform duration-300 ease-in-out h-full"
+                    :style="{ transform: `translateX(-${currentSlide * 100}%)` }"
+                  >
+                    <!-- 첫 번째 목표 카드 -->
+                    <div class="min-w-full h-full flex">
+                      <div class="w-full h-[170px] bg-white p-4 relative">
+                        <div class="absolute left-4 top-4 w-[250px] h-[117px]">
+                          <div class="flex items-center text-black text-xs font-semibold">
+                            <svg
+                              xmlns="http://www.w3.org/2000/svg"
+                              class="h-4 w-4 mr-2 text-blue-600"
+                              fill="none"
+                              viewBox="0 0 24 24"
+                              stroke="currentColor"
+                            >
+                              <path
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                                stroke-width="2"
+                                d="M19 14l-7 7m0 0l-7-7m7 7V3"
+                              />
+                            </svg>
+                            자가용 구매하기
+                          </div>
+                        </div>
+
+                        <div class="absolute right-4 top-6">
+                          <div class="bg-green-500 rounded-full h-5 px-3 flex items-center justify-center">
+                            <span class="text-white text-xs font-semibold">목표 달성 !</span>
+                          </div>
+                        </div>
+
+                        <div class="absolute left-4 top-18 flex flex-wrap gap-1 text-xs">
+                          <div class="flex items-center">
+                            <div class="w-2 h-2 rounded-sm mr-1 bg-green-500"></div>
+                            <span class="text-gray-600">주거래 60%</span>
+                          </div>
+                          <div class="flex items-center">
+                            <div class="w-2 h-2 rounded-sm mr-1 bg-green-600"></div>
+                            <span class="text-gray-600">적금 40%</span>
+                          </div>
+                        </div>
+
+                        <div class="absolute left-4 bottom-16 w-[calc(100%-32px)] h-3">
+                          <div class="bg-gray-300 rounded-full h-3 w-full relative overflow-hidden">
+                            <div class="bg-green-500 h-3 rounded-l-full absolute left-0" style="width: 60%"></div>
+                            <div class="bg-green-600 h-3 rounded-r-full absolute" style="width: 40%; left: 60%"></div>
+                          </div>
+                        </div>
+
+                        <div class="bg-green-50 rounded-lg h-10 w-[calc(100%-32px)] absolute left-4 bottom-4 p-2">
+                          <div class="text-green-800 text-xs font-bold">예상 달성일: 2025-12-28</div>
+                          <div class="text-green-600 text-xs">목표보다 199일 빠름</div>
+                        </div>
+                      </div>
+                    </div>
+
+                    <!-- 두 번째 목표 카드 -->
+                    <div class="min-w-full h-full flex">
+                      <div class="w-full h-[170px] bg-white p-4 relative">
+                        <div class="absolute left-4 top-4 w-[250px]">
+                          <div class="flex items-center text-black text-xs font-semibold">
+                            <svg
+                              xmlns="http://www.w3.org/2000/svg"
+                              class="h-4 w-4 mr-2 text-blue-600"
+                              fill="none"
+                              viewBox="0 0 24 24"
+                              stroke="currentColor"
+                            >
+                              <path
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                                stroke-width="2"
+                                d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8"
+                              />
+                            </svg>
+                            유럽 여행 자금
+                          </div>
+                          <div class="text-blue-600 text-xs mt-2 font-medium">진행 중 (75%)</div>
+                        </div>
+
+                        <div class="absolute right-4 top-6">
+                          <div class="bg-blue-500 rounded-full h-5 px-3 flex items-center justify-center">
+                            <span class="text-white text-xs font-semibold">75%</span>
+                          </div>
+                        </div>
+
+                        <div class="absolute left-4 top-18 flex flex-wrap gap-1 text-xs">
+                          <div class="flex items-center">
+                            <div class="w-2 h-2 rounded-sm mr-1 bg-blue-500"></div>
+                            <span class="text-gray-600">주거래 40%</span>
+                          </div>
+                          <div class="flex items-center">
+                            <div class="w-2 h-2 rounded-sm mr-1 bg-cyan-500"></div>
+                            <span class="text-gray-600">적금 25%</span>
+                          </div>
+                          <div class="flex items-center">
+                            <div class="w-2 h-2 rounded-sm mr-1 bg-purple-500"></div>
+                            <span class="text-gray-600">투자 10%</span>
+                          </div>
+                        </div>
+
+                        <div class="absolute left-4 bottom-16 w-[calc(100%-32px)] h-3">
+                          <div class="bg-gray-300 rounded-full h-3 w-full relative overflow-hidden">
+                            <div class="bg-blue-500 h-3 absolute left-0" style="width: 40%"></div>
+                            <div class="bg-cyan-500 h-3 absolute" style="width: 25%; left: 40%"></div>
+                            <div class="bg-purple-500 h-3 absolute" style="width: 10%; left: 65%"></div>
+                          </div>
+                        </div>
+
+                        <div class="bg-blue-50 rounded-lg h-10 w-[calc(100%-32px)] absolute left-4 bottom-2 p-2">
+                          <div class="text-blue-800 text-xs font-bold">예상 달성일: 2025-08-20</div>
+                          <div class="text-blue-600 text-xs">1,500,000원 / 2,000,000원</div>
+                        </div>
+                      </div>
+                    </div>
+
+                    <!-- 세 번째 목표 카드 -->
+                    <div class="min-w-full h-full flex">
+                      <div class="w-full h-[170px] bg-white p-4 relative">
+                        <div class="absolute left-4 top-4 w-[250px]">
+                          <div class="flex items-center text-black text-xs font-semibold">
+                            <svg
+                              xmlns="http://www.w3.org/2000/svg"
+                              class="h-4 w-4 mr-2 text-green-600"
+                              fill="none"
+                              viewBox="0 0 24 24"
+                              stroke="currentColor"
+                            >
+                              <path
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                                stroke-width="2"
+                                d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1"
+                              />
+                            </svg>
+                            비상 자금 마련
+                          </div>
+                          <div class="text-orange-600 text-xs mt-2 font-medium">진행 중 (45%)</div>
+                        </div>
+
+                        <div class="absolute right-4 top-6">
+                          <div class="bg-orange-500 rounded-full h-5 px-3 flex items-center justify-center">
+                            <span class="text-white text-xs font-semibold">45%</span>
+                          </div>
+                        </div>
+
+                        <div class="absolute left-4 top-18 flex flex-wrap gap-1 text-xs">
+                          <div class="flex items-center">
+                            <div class="w-2 h-2 rounded-sm mr-1 bg-orange-500"></div>
+                            <span class="text-gray-600">비상금 30%</span>
+                          </div>
+                          <div class="flex items-center">
+                            <div class="w-2 h-2 rounded-sm mr-1 bg-yellow-500"></div>
+                            <span class="text-gray-600">예금 15%</span>
+                          </div>
+                        </div>
+
+                        <div class="absolute left-4 bottom-16 w-[calc(100%-32px)] h-3">
+                          <div class="bg-gray-300 rounded-full h-3 w-full relative overflow-hidden">
+                            <div class="bg-orange-500 h-3 absolute left-0" style="width: 30%"></div>
+                            <div class="bg-yellow-500 h-3 absolute" style="width: 15%; left: 30%"></div>
+                          </div>
+                        </div>
+
+                        <div class="bg-orange-50 rounded-lg h-10 w-[calc(100%-32px)] absolute left-4 bottom-2 p-2">
+                          <div class="text-orange-800 text-xs font-bold">예상 달성일: 2026-03-15</div>
+                          <div class="text-orange-600 text-xs">4,500,000원 / 10,000,000원</div>
+                        </div>
+                      </div>
+                    </div>
+
+                    <!-- 목표 추가 버튼 -->
+                    <div class="min-w-full h-full flex">
+                      <button
+                        class="w-full h-[170px] bg-white border-2 border-dashed border-gray-300 hover:border-indigo-400 hover:bg-indigo-50 transition-colors duration-200 flex flex-col items-center justify-center group"
+                      >
+                        <div
+                          class="w-12 h-12 rounded-full bg-gray-100 group-hover:bg-indigo-100 flex items-center justify-center mb-3 transition-colors duration-200"
+                        >
+                          <svg
+                            xmlns="http://www.w3.org/2000/svg"
+                            class="h-6 w-6 text-gray-400 group-hover:text-indigo-600 transition-colors duration-200"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                            stroke="currentColor"
+                          >
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+                          </svg>
+                        </div>
+
+                        <div class="text-center">
+                          <p
+                            class="text-gray-600 group-hover:text-indigo-600 text-sm font-medium transition-colors duration-200"
+                          >
+                            새 목표 추가
+                          </p>
+                          <p
+                            class="text-gray-400 group-hover:text-indigo-400 text-xs mt-1 transition-colors duration-200"
+                          >
+                            목표를 설정하고 달성해보세요
+                          </p>
+                        </div>
+                      </button>
+                    </div>
                   </div>
-                  <h3 class="text-base font-semibold text-gray-800 whitespace-nowrap">최근 투자 현황</h3>
                 </div>
-                <button class="text-xs text-indigo-600 font-medium whitespace-nowrap">전체보기</button>
-              </div>
 
-              <!-- Asset and ROI Summary -->
-              <div class="flex justify-between items-baseline mb-3">
-                <div class="min-w-0 flex-shrink-0">
-                  <p class="text-sm text-gray-500 whitespace-nowrap">총 투자 자산</p>
-                  <p class="text-xl font-bold whitespace-nowrap">12,450,000원</p>
+                <!-- Slide Indicators -->
+                <div class="absolute bottom-2 left-1/2 transform -translate-x-1/2 flex space-x-2">
+                  <button
+                    v-for="(slide, index) in 4"
+                    :key="index"
+                    @click="currentSlide = index"
+                    :class="[
+                      'w-2 h-2 rounded-full transition-colors',
+                      currentSlide === index ? 'bg-indigo-600' : 'bg-gray-300',
+                    ]"
+                  ></button>
                 </div>
-                <div class="text-right min-w-0 flex-shrink-0">
-                  <p class="text-sm text-gray-500 whitespace-nowrap">총 수익률</p>
-                  <p class="text-xl font-bold text-green-600 whitespace-nowrap">+8.2%</p>
-                </div>
-              </div>
 
-              <!-- Time Period Toggle Buttons -->
-              <div class="flex justify-center space-x-1 bg-gray-100 rounded-lg p-1 mb-3">
+                <!-- Navigation Arrows -->
                 <button
-                  @click="selectPeriod('daily')"
-                  :class="[
-                    'w-full py-1 text-xs rounded-md transition-colors duration-200',
-                    selectedPeriod === 'daily' ? 'bg-white text-indigo-600 shadow' : 'text-gray-500 hover:bg-gray-200',
-                  ]"
+                  v-if="currentSlide > 0"
+                  @click="previousSlide"
+                  class="absolute left-2 top-1/2 transform -translate-y-1/2 bg-white rounded-full w-8 h-8 flex items-center justify-center shadow-lg hover:bg-gray-50 transition-colors z-20"
                 >
-                  일
+                  <span class="text-gray-600">‹</span>
                 </button>
+
                 <button
-                  @click="selectPeriod('weekly')"
-                  :class="[
-                    'w-full py-1 text-xs rounded-md transition-colors duration-200',
-                    selectedPeriod === 'weekly' ? 'bg-white text-indigo-600 shadow' : 'text-gray-500 hover:bg-gray-200',
-                  ]"
+                  v-if="currentSlide < 3"
+                  @click="nextSlide"
+                  class="absolute right-2 top-1/2 transform -translate-y-1/2 bg-white rounded-full w-8 h-8 flex items-center justify-center shadow-lg hover:bg-gray-50 transition-colors z-20"
                 >
-                  주
-                </button>
-                <button
-                  @click="selectPeriod('monthly')"
-                  :class="[
-                    'w-full py-1 text-xs rounded-md transition-colors duration-200',
-                    selectedPeriod === 'monthly'
-                      ? 'bg-white text-indigo-600 shadow'
-                      : 'text-gray-500 hover:bg-gray-200',
-                  ]"
-                >
-                  월
+                  <span class="text-gray-600">›</span>
                 </button>
               </div>
 
-              <!-- Investment Chart -->
-              <div class="h-[150px]">
-                <v-chart class="w-full h-full" :option="investmentChartOption" autoresize />
-              </div>
+              <!-- Investment Status Section -->
+              <div class="h-auto w-[calc(100%-16px)] max-w-[380px] bg-white rounded-2xl shadow-lg p-5">
+                <!-- Header -->
+                <div class="flex justify-between items-center mb-2">
+                  <div class="flex items-center">
+                    <div class="text-indigo-600 mr-2">
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        class="h-5 w-5"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                      >
+                        <path
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="2"
+                          d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6"
+                        />
+                      </svg>
+                    </div>
+                    <h3 class="text-base font-semibold text-gray-800 whitespace-nowrap">최근 투자 현황</h3>
+                  </div>
+                  <button class="text-xs text-indigo-600 font-medium whitespace-nowrap">전체보기</button>
+                </div>
 
-              <!-- Quick Actions -->
-              <div class="flex justify-between mt-4">
-                <button
-                  class="flex items-center justify-center bg-indigo-50 text-indigo-600 rounded-lg py-2 px-4 text-xs font-medium"
-                >
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    class="h-4 w-4 mr-1"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
+                <!-- Asset and ROI Summary -->
+                <div class="flex justify-between items-baseline mb-3">
+                  <div class="min-w-0 flex-shrink-0">
+                    <p class="text-sm text-gray-500 whitespace-nowrap">총 투자 자산</p>
+                    <p class="text-xl font-bold whitespace-nowrap">12,450,000원</p>
+                  </div>
+                  <div class="text-right min-w-0 flex-shrink-0">
+                    <p class="text-sm text-gray-500 whitespace-nowrap">총 수익률</p>
+                    <p class="text-xl font-bold text-green-600 whitespace-nowrap">+8.2%</p>
+                  </div>
+                </div>
+
+                <!-- Time Period Toggle Buttons -->
+                <div class="flex justify-center space-x-1 bg-gray-100 rounded-lg p-1 mb-3">
+                  <button
+                    @click="selectPeriod('daily')"
+                    :class="[
+                      'w-full py-1 text-xs rounded-md transition-colors duration-200',
+                      selectedPeriod === 'daily'
+                        ? 'bg-white text-indigo-600 shadow'
+                        : 'text-gray-500 hover:bg-gray-200',
+                    ]"
                   >
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      d="M12 6v6m0 0v6m0-6h6m-6 0H6"
-                    />
-                  </svg>
-                  투자 추가
-                </button>
-                <button
-                  class="flex items-center justify-center bg-indigo-50 text-indigo-600 rounded-lg py-2 px-4 text-xs font-medium"
-                >
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    class="h-4 w-4 mr-1"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
+                    일
+                  </button>
+                  <button
+                    @click="selectPeriod('weekly')"
+                    :class="[
+                      'w-full py-1 text-xs rounded-md transition-colors duration-200',
+                      selectedPeriod === 'weekly'
+                        ? 'bg-white text-indigo-600 shadow'
+                        : 'text-gray-500 hover:bg-gray-200',
+                    ]"
                   >
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"
-                    />
-                  </svg>
-                  분석 보기
-                </button>
+                    주
+                  </button>
+                  <button
+                    @click="selectPeriod('monthly')"
+                    :class="[
+                      'w-full py-1 text-xs rounded-md transition-colors duration-200',
+                      selectedPeriod === 'monthly'
+                        ? 'bg-white text-indigo-600 shadow'
+                        : 'text-gray-500 hover:bg-gray-200',
+                    ]"
+                  >
+                    월
+                  </button>
+                </div>
+
+                <!-- Investment Chart -->
+                <div class="h-[150px]">
+                  <v-chart class="w-full h-full" :option="investmentChartOption" autoresize />
+                </div>
+
+                <!-- Quick Actions -->
+                <div class="flex justify-between mt-4">
+                  <button
+                    class="flex items-center justify-center bg-indigo-50 text-indigo-600 rounded-lg py-2 px-4 text-xs font-medium"
+                  >
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      class="h-4 w-4 mr-1"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                    >
+                      <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        d="M12 6v6m0 0v6m0-6h6m-6 0H6"
+                      />
+                    </svg>
+                    투자 추가
+                  </button>
+                  <button
+                    class="flex items-center justify-center bg-indigo-50 text-indigo-600 rounded-lg py-2 px-4 text-xs font-medium"
+                  >
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      class="h-4 w-4 mr-1"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                    >
+                      <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"
+                      />
+                    </svg>
+                    분석 보기
+                  </button>
+                </div>
               </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
 
-    <!-- 하단 고정 내비게이션 -->
-    <NavBar class="absolute bottom-0 left-0 right-0 z-30" />
-  </div>
+      <!-- 하단 고정 내비게이션 -->
+    </div>
+  </MainLayout>
 </template>
 
 <script>
@@ -452,6 +456,7 @@ import headerBg from "@/assets/images/headerBackground.svg";
 import logoSvg from "@/assets/images/Logo.svg";
 import MainHeader from "@/components/common/MainHeader.vue";
 import NavBar from "@/components/common/NavBar.vue";
+import MainLayout from "@/components/layouts/MainLayout.vue";
 
 use([CanvasRenderer, PieChart, LineChart, TitleComponent, TooltipComponent, LegendComponent, GridComponent]);
 
@@ -461,6 +466,7 @@ export default {
     MainHeader,
     NavBar,
     VChart,
+    MainLayout,
   },
   setup() {
     const currentSlide = ref(0);

--- a/src/views/goal/GoalDetailView.vue
+++ b/src/views/goal/GoalDetailView.vue
@@ -23,7 +23,6 @@
           </button>
         </div>
 
-        <!-- 목표 제목 -->
         <div class="mb-4">
           <h2 class="text-lg font-semibold text-gray-800 mb-1">{{ goalTitle }}</h2>
           <div class="flex items-center">
@@ -34,7 +33,6 @@
           </div>
         </div>
 
-        <!-- 진행률 바 -->
         <div class="mb-4">
           <div class="flex justify-between text-sm text-gray-600 mb-2">
             <span>{{ currentAmount }}만원</span>
@@ -47,10 +45,15 @@
       <!-- 목표에 할당된 계좌 섹션 -->
       <div class="bg-white rounded-2xl shadow-sm mx-4 mb-4 p-5">
         <h3 class="text-lg font-semibold text-gray-800 mb-4">목표에 할당된 계좌</h3>
-
-        <GoalAssignedCard bank-name="토스" product-name="예금 · 주택청약" percent="15" amount="675" class="mb-3" />
-        <GoalAssignedCard bank-name="KB" product-name="적금 · 주택청약" percent="60" amount="2700" class="mb-3" />
-        <GoalAssignedCard bank-name="카카오뱅크" product-name="자유적금" percent="25" amount="1125" class="mb-4" />
+        <GoalAssignedCard
+          v-for="(account, index) in accounts"
+          :key="index"
+          :bank-name="account.bankName"
+          :product-name="account.productName"
+          :percent="account.percent"
+          :amount="account.amount"
+          class="mb-3"
+        />
       </div>
 
       <!-- 목표 금액 및 저축액 요약 -->
@@ -65,7 +68,6 @@
             <p class="text-2xl font-bold text-green-600">{{ currentAmount }}만원</p>
           </div>
         </div>
-
         <div class="border-t pt-4">
           <div class="flex justify-between items-center">
             <p class="text-sm font-medium text-gray-700">목표 금액까지</p>
@@ -74,11 +76,10 @@
         </div>
       </div>
 
-      <!-- 목표 진행 추이 요약 섹션 -->
+      <!-- 목표 진행 요약 및 차트 -->
       <div class="bg-white rounded-2xl shadow-sm mx-4 mb-4 p-5">
         <h3 class="text-lg font-semibold text-gray-800 mb-4">주식 진행 추이</h3>
 
-        <!-- 차트 영역 -->
         <div class="mb-6 h-48 bg-gray-50 rounded-lg flex items-center justify-center border-2 border-purple-200">
           <div class="text-center text-gray-500">
             <div class="text-sm mb-2">주식 진행 추이 차트</div>
@@ -86,7 +87,6 @@
           </div>
         </div>
 
-        <!-- 요약 한마디 -->
         <div class="mb-6 flex justify-center">
           <SummaryCard>
             <template #title>🔍 목표 진행 요약</template>
@@ -95,11 +95,9 @@
           </SummaryCard>
         </div>
 
-        <!-- 특정 기간 리밸런싱 -->
+        <!-- 리밸런싱 -->
         <div class="mb-4">
           <h4 class="text-base font-semibold text-gray-800 mb-3">특정 기간 리밸런싱</h4>
-
-          <!-- 기간 선택 버튼 -->
           <div class="flex gap-2 mb-4">
             <button
               v-for="period in periods"
@@ -115,7 +113,6 @@
               {{ period }}
             </button>
           </div>
-
           <RebalanceCard
             title="한달"
             expected-yield="8.2%"
@@ -128,7 +125,7 @@
           />
         </div>
 
-        <!-- OOO + GLD 포트폴리오 -->
+        <!-- 포트폴리오 & 코인 -->
         <div class="mb-4">
           <h4 class="text-base font-semibold text-gray-800 mb-3">QQQ + QLD 포트폴리오</h4>
           <div class="bg-gray-50 rounded-lg p-4">
@@ -145,7 +142,6 @@
           </div>
         </div>
 
-        <!-- 코인 보유 종목 -->
         <div class="mb-4">
           <h4 class="text-base font-semibold text-gray-800 mb-3">코인 보유 종목</h4>
           <div class="bg-gray-50 rounded-lg p-4">
@@ -170,7 +166,7 @@
   </DefaultLayout>
 </template>
 
-<script>
+<script setup>
 import { ref, computed } from "vue";
 import BarChart from "@/components/graph/BarChart.vue";
 import GoalAssignedCard from "@/components/manageGoal/GoalAssignedCard.vue";
@@ -178,69 +174,24 @@ import SummaryCard from "@/components/common/SummaryCard.vue";
 import RebalanceCard from "@/components/goal/RebalanceCard.vue";
 import DefaultLayout from "@/components/layouts/DefaultLayout.vue";
 
-export default {
-  name: "GoalDetailView",
-  components: {
-    BarChart,
-    GoalAssignedCard,
-    SummaryCard,
-    RebalanceCard,
-    DefaultLayout,
-  },
-  setup() {
-    // 목표 정보
-    const goalTitle = ref("자가용 구매하기");
-    const targetAmount = ref(5000);
+// Props (나중에 외부에서 넘기도록 할 수 있음)
+const goalTitle = ref("자가용 구매하기");
+const targetAmount = ref(5000);
 
-    // 리밸런싱 기간 선택
-    const periods = ref(["한달", "3개월", "6개월", "1년"]);
-    const selectedPeriod = ref("한달");
+const accounts = ref([
+  { bankName: "토스", productName: "예금 · 주택청약", percent: 15, amount: 675 },
+  { bankName: "KB", productName: "적금 · 주택청약", percent: 60, amount: 2700 },
+  { bankName: "카카오뱅크", productName: "자유적금", percent: 25, amount: 1125 },
+]);
 
-    // 계좌별 데이터
-    const accounts = ref([
-      {
-        bankName: "토스",
-        productName: "예금 · 주택청약",
-        percent: 15,
-        amount: 675,
-      },
-      {
-        bankName: "KB",
-        productName: "적금 · 주택청약",
-        percent: 60,
-        amount: 2700,
-      },
-      {
-        bankName: "카카오뱅크",
-        productName: "자유적금",
-        percent: 25,
-        amount: 1125,
-      },
-    ]);
+const currentAmount = computed(() => {
+  return accounts.value.reduce((sum, acc) => sum + acc.amount, 0);
+});
 
-    // 계산된 값들
-    const currentAmount = computed(() => {
-      return accounts.value.reduce((total, account) => total + Number(account.amount), 0);
-    });
+const remainingAmount = computed(() => targetAmount.value - currentAmount.value);
+const progressPercentage = computed(() => Math.round((currentAmount.value / targetAmount.value) * 100));
 
-    const remainingAmount = computed(() => {
-      return targetAmount.value - currentAmount.value;
-    });
-
-    const progressPercentage = computed(() => {
-      return Math.round((currentAmount.value / targetAmount.value) * 100);
-    });
-
-    return {
-      goalTitle,
-      targetAmount,
-      currentAmount,
-      remainingAmount,
-      progressPercentage,
-      accounts,
-      periods,
-      selectedPeriod,
-    };
-  },
-};
+// 리밸런싱 기간
+const periods = ref(["한달", "3개월", "6개월", "1년"]);
+const selectedPeriod = ref("한달");
 </script>


### PR DESCRIPTION
## 🔖 PR 유형
- [ ] ✨ 기능 추가
- [ ] 🐛 버그 수정
- [ ] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요
각 페이지에서 네비게이션바의 위치가 일관되지 않아 수정하였습니다

## 🔧 작업 내용
- `flex-shrink-0` 클래스를 `sticky`로 변경하여 요소를 하단에 고정
- Composition API 기반 컴포넌트 방식에서 Composition API + <script setup> + props/emit 기반의 API 컴포넌트 형식으로 변경
🔧 좀 더 자세히 설명하면:
✅ 1. 기존 구조는 Options API (export default) 사용
DefaultLayout.vue 같은 레이아웃 컴포넌트는 보통 <slot /> 자리에 자식 콘텐츠가 렌더링되길 기대합니다.

하지만 이전의 export default 방식에서는 템플릿이나 구조상 오류(예: <template>이 두 번 중첩됨, 또는 slot이 이상하게 감싸짐)로 인해 slot이 제대로 렌더링되지 않았을 가능성이 있습니다.

✅ 2. Composition API로 바꾸면 slot 렌더링 구조가 더 깔끔해짐
<script setup>은 Vue 3에서 훨씬 명확하고 predictable한 방식입니다.

이 구조에서는 템플릿과 로직이 자동으로 연결되고, 부모 slot에도 잘 맞게 렌더링됩니다.

그래서 DefaultLayout.vue 내부에 있는 NavBar, 혹은 position: fixed / absolute 처리된 요소들이 예상한 위치에 정확히 정렬된 겁니다.

## ✅ 체크리스트
- [ ] 테스트 완료(Postman, Swagger)

## 📝 기타 참고 사항
- 주의할 점, 추후 리팩토링 필요성 등

## 📎 관련 이슈
Close #74 