### PR TITLE
[FEAT] 투자조사결과  UI 수정 및 완료버튼시 백엔드 API investType 결과 전송

### DIFF
--- a/src/router/onBoarding.js
+++ b/src/router/onBoarding.js
@@ -1,54 +1,53 @@
 export default [
   {
-    path: '/bank-select',
-    name: 'bank-select',
-    component: () => import('../views/onBoarding/BankSelectView.vue'),
+    path: "/bank-select",
+    name: "bank-select",
+    component: () => import("../views/onBoarding/BankSelectView.vue"),
     meta: { layout: "noHeader", requiresAuth: true },
   },
   {
     path: "/bank-login",
     name: "bankLogin",
-    component: () => import('../views/onBoarding/BankLoginView.vue'),
+    component: () => import("../views/onBoarding/BankLoginView.vue"),
     meta: { layout: "noHeader", requiresAuth: true },
   },
   {
     path: "/bank-linking-success",
     name: "bankLinkingSuccess",
-    component: () => import('../views/onBoarding/BankLinkingSuccessView.vue'),
+    component: () => import("../views/onBoarding/BankLinkingSuccessView.vue"),
     meta: { layout: "noHeader", requiresAuth: true },
   },
   {
     path: "/login",
     name: "login",
-    component: () => import('../views/onBoarding/LoginPage.vue'),
+    component: () => import("../views/onBoarding/LoginPage.vue"),
     meta: { layout: "noHeader" },
   },
   {
     path: "/investment-survey",
     name: "investmentSurvey",
-    component: () => import('../views/onBoarding/InvestmentSurveyView.vue'),
+    component: () => import("../views/onBoarding/InvestmentSurveyView.vue"),
     meta: { layout: "onboardHeader", requiresAuth: true },
   },
   {
     path: "/investment-survey/result",
     name: "investmentSurveyResult",
-    component: () => import('../views/onBoarding/InvestmentSurveyResult.vue'),
+    component: () => import("../views/onBoarding/InvestmentSurveyResult.vue"),
     meta: { layout: "noHeader", requiresAuth: true },
   },
   {
     path: "/onboard-loading",
     name: "onboardLoading",
-    component: () => import('../views/onBoarding/OnboardLoadingView.vue'),
+    component: () => import("../views/onBoarding/OnboardLoadingView.vue"),
     meta: { layout: "noHeader" },
   },
   {
     path: "/survey-loading",
     name: "surveyLoading",
-    component: () => import('../views/onBoarding/SurveyLoadingView.vue'),
+    component: () => import("../views/onBoarding/SurveyLoadingView.vue"),
     meta: { layout: "noHeader", requiresAuth: true },
   },
   {
     path: "/survey-result",
-  }
+  },
 ];
-

--- a/src/views/onBoarding/InvestmentSurveyResult.vue
+++ b/src/views/onBoarding/InvestmentSurveyResult.vue
@@ -1,26 +1,36 @@
 <template>
   <div class="min-h-screen w-full flex flex-col items-center justify-center relative overflow-hidden">
-    <!-- 배경 이미지 -->
     <img
       src="@/assets/images/background.png"
       alt="Result Background"
       class="absolute inset-0 w-full h-full object-cover z-0"
     />
     <div class="relative z-10 flex flex-col items-center justify-center min-h-screen w-full">
+      <div class="flex flex-col items-center mb-8">
+        <!-- <h1 class="text-3xl font-bold text-white mb-6">나의 투자성향</h1> -->
+        <img :src="characterImg" :alt="resultInfo.name" class="w-40 h-40 object-contain" />
+      </div>
+
       <div
-        class="bg-white/80 rounded-3xl shadow-lg px-8 py-10 flex flex-col items-center max-w-md w-full mt-16 relative pt-24"
+        class="bg-white/10 border-white border-1 rounded-3xl shadow-lg px-8 py-8 flex flex-col items-center max-w-xs w-full relative"
       >
-        <img
-          :src="characterImg"
-          :alt="resultInfo.name"
-          class="w-40 h-40 object-contain absolute left-1/2 -translate-x-1/2 -top-20 z-10"
-        />
-        <div class="text-2xl font-extrabold text-center mb-2">{{ resultInfo.name }}</div>
-        <div class="text-lg font-semibold text-gray-700 text-center mb-1">{{ resultInfo.type }}</div>
-        <div class="text-base text-gray-600 text-center mb-4">{{ resultInfo.desc }}</div>
-        <button class="mt-4 px-6 py-2 rounded-lg bg-[#B9AFFF] text-white font-bold shadow" @click="goHome">
-          홈으로
-        </button>
+        <div class="text-2xl font-extrabold text-center mb-5 text-white">{{ resultInfo.name }}</div>
+        <div class="text-lg font-semibold text-center mb-2 text-gray-200">{{ resultInfo.type }}</div>
+        <div class="text-base text-center mb-4 text-gray-400">{{ resultInfo.desc }}</div>
+        <div class="flex w-full justify-between mt-4">
+          <button
+            class="px-6 py-2 rounded-lg bg-transparent text-gray-100 font-bold shadow border-white border-1"
+            @click="Retry"
+          >
+            다시하기
+          </button>
+          <button
+            class="px-6 py-2 rounded-lg bg-[#B9AFFF] text-white font-bold shadow border-white border-1"
+            @click="goHome"
+          >
+            완료
+          </button>
+        </div>
       </div>
     </div>
   </div>
@@ -29,6 +39,7 @@
 <script setup>
 import { computed } from "vue";
 import { useRoute, useRouter } from "vue-router";
+import { api } from "@/services/api";
 
 const route = useRoute();
 const router = useRouter();
@@ -37,43 +48,67 @@ const resultMap = {
   안전형: {
     name: "크레이터",
     type: "안전형",
+    apiType: "CONSERVATIVE",
     desc: "안정성과 원금 보전을 최우선으로 생각하는 투자자입니다. 예금, 적금, 채권 등 저위험 상품을 선호합니다.",
-    img: "crater.png",
+    img: "creator.svg",
   },
   안정추구형: {
     name: "가이아",
     type: "안정추구형",
+    apiType: "STABLE",
     desc: "안정적인 수익과 약간의 성장 가능성을 추구합니다. 분산 투자와 중위험 상품에 관심이 많습니다.",
     img: "gaia.png",
   },
   위험중립형: {
     name: "루나",
     type: "위험중립형",
+    apiType: "NEUTRAL",
     desc: "위험과 수익의 균형을 중시하며, 다양한 자산에 투자하는 것을 선호합니다.",
-    img: "lunar.png",
+    img: "luna.svg",
   },
   적극투자형: {
     name: "볼케이노",
     type: "적극투자형",
+    apiType: "GROWTH",
     desc: "높은 수익을 위해 일정 수준의 위험도 감수할 수 있는 투자자입니다.",
-    img: "volcano.png",
+    img: "volcano.svg",
   },
   공격투자형: {
     name: "네뷸라",
     type: "공격투자형",
+    apiType: "AGGRESSIVE",
     desc: "최고의 수익을 위해 높은 위험도 마다하지 않는 투자자입니다. 주식, 파생상품, 가상자산 등 고위험 상품에 관심이 많습니다.",
-    img: "nebula.png",
+    img: "nevula.svg",
   },
 };
 
 const resultType = route.query.type || "안전형";
 const resultInfo = resultMap[resultType] || resultMap["안전형"];
-const characterImg = computed(
-  () => new URL(`../../assets/images/invest-survey/${resultInfo.img}`, import.meta.url).href
-);
+const characterImg = computed(() => new URL(`../../assets/images/${resultInfo.img}`, import.meta.url).href);
 
-function goHome() {
-  router.push("/");
+async function goHome() {
+  const investType = resultInfo.apiType;
+  const apiUrl = "/member/invest-type";
+
+  try {
+    // api 유틸리티를 사용해 POST 요청
+    const response = await api.post(apiUrl, null, {
+      params: {
+        type: investType,
+      },
+    });
+
+    if (response.status === 200) {
+      console.log("투자 성향이 성공적으로 저장되었습니다.");
+      router.push("/");
+    }
+  } catch (error) {
+    console.error("투자 성향 저장 중 오류가 발생했습니다:", error);
+    alert("오류가 발생했습니다. 다시 시도해 주세요.");
+  }
+}
+function Retry() {
+  router.push("/investment-survey");
 }
 </script>
 

--- a/src/views/onBoarding/InvestmentSurveyView.vue
+++ b/src/views/onBoarding/InvestmentSurveyView.vue
@@ -1,54 +1,44 @@
 <template>
   <SubLayout>
-    <template v-if="!showResult">
-      <!-- Progress Bar -->
-      <div class="w-full mb-6">
-        <div class="flex justify-between items-center mb-2">
-          <span class="text-xs text-gray-400">진행률</span>
-          <span class="text-xs text-gray-400">{{ currentIndex + 1 }}/{{ questions.length }}</span>
-        </div>
-        <div class="w-full bg-gray-200 rounded-full h-2.5">
-          <div
-            class="bg-[#4B3C8A] h-2.5 rounded-full"
-            :style="{ width: ((currentIndex + 1) / questions.length) * 100 + '%' }"
-          ></div>
-        </div>
+    <!-- Progress Bar -->
+    <div class="w-full mb-6">
+      <div class="flex justify-between items-center mb-2">
+        <span class="text-xs text-gray-400">진행률</span>
+        <span class="text-xs text-gray-400">{{ currentIndex + 1 }}/{{ questions.length }}</span>
       </div>
-      <!-- 질문 -->
-      <div class="mb-6 font-bold text-gray-800 text-base w-full">
-        {{ questions[currentIndex].question }}
+      <div class="w-full bg-gray-200 rounded-full h-2.5">
+        <div
+          class="bg-[#4B3C8A] h-2.5 rounded-full"
+          :style="{ width: ((currentIndex + 1) / questions.length) * 100 + '%' }"
+        ></div>
       </div>
-      <!-- 체크리스트 -->
-      <form class="w-full">
-        <div class="flex flex-col gap-3 text-sm text-gray-700">
-          <label v-for="(choice, idx) in questions[currentIndex].choices" :key="idx" class="flex items-center gap-2">
-            <input type="radio" :name="'q' + currentIndex" :value="idx" v-model="selected" />
-            {{ choice.text }}
-          </label>
-        </div>
-      </form>
-      <!-- 다음/완료 버튼 -->
-      <button
-        class="w-full py-3 rounded-lg text-white font-semibold bg-[#B9AFFF] shadow-md disabled:bg-[#B9AFFF]/50 transition mt-8"
-        :disabled="selected === null"
-        @click="nextOrFinish"
-      >
-        {{ currentIndex === questions.length - 1 ? "완료" : "다음" }}
-      </button>
-    </template>
-    <template v-else>
-      <div class="w-full flex flex-col items-center justify-center h-full">
-        <div class="text-lg font-bold mb-4">당신의 투자 성향은?</div>
-        <div class="text-2xl font-extrabold text-[#4B3C8A] mb-2">{{ resultType }}</div>
-        <div class="text-gray-700">가장 높은 점수를 받은 성향입니다.</div>
-        <button class="mt-8 text-[#4B3C8A] underline" @click="resetSurvey">다시하기</button>
+    </div>
+    <!-- 질문 -->
+    <div class="mb-6 font-bold text-gray-800 text-base w-full">
+      {{ questions[currentIndex].question }}
+    </div>
+    <!-- 체크리스트 -->
+    <form class="w-full">
+      <div class="flex flex-col gap-3 text-sm text-gray-700">
+        <label v-for="(choice, idx) in questions[currentIndex].choices" :key="idx" class="flex items-center gap-2">
+          <input type="radio" :name="'q' + currentIndex" :value="idx" v-model="selected" />
+          {{ choice.text }}
+        </label>
       </div>
-    </template>
+    </form>
+    <!-- 다음/완료 버튼 -->
+    <button
+      class="w-full py-3 rounded-lg text-white font-semibold bg-[#B9AFFF] shadow-md disabled:bg-[#B9AFFF]/50 transition mt-8"
+      :disabled="selected === null"
+      @click="nextOrFinish"
+    >
+      {{ currentIndex === questions.length - 1 ? "완료" : "다음" }}
+    </button>
   </SubLayout>
 </template>
 
 <script setup>
-import { ref, computed, watch } from "vue";
+import { ref, computed } from "vue";
 import { useRouter } from "vue-router";
 import SubLayout from "@/components/layouts/SubLayout.vue";
 
@@ -115,7 +105,6 @@ const currentIndex = ref(0);
 const selected = ref(null);
 const answers = ref([]); // 각 문항별 선택 인덱스
 const scores = ref([0, 0, 0, 0, 0]);
-const showResult = ref(false);
 
 const resultType = computed(() => {
   const max = Math.max(...scores.value);
@@ -125,39 +114,29 @@ const resultType = computed(() => {
 
 const router = useRouter();
 
-watch(showResult, (val) => {
-  if (val) {
-    router.push({
-      name: "InvestmentSurveyResult",
-      query: { type: resultType.value },
-    });
-  }
-});
-
 function nextOrFinish() {
   if (selected.value === null) return;
+
   // 선택값 저장
   answers.value[currentIndex.value] = selected.value;
+
   // 점수 누적
   const choiceScores = questions[currentIndex.value].choices[selected.value].scores;
   for (let i = 0; i < scores.value.length; i++) {
     scores.value[i] += choiceScores[i];
   }
-  // 다음 문항 or 결과
+
+  // 다음 문항 or 결과 페이지로 이동
   if (currentIndex.value < questions.length - 1) {
     currentIndex.value++;
     selected.value = answers.value[currentIndex.value] ?? null;
   } else {
-    showResult.value = true;
+    // 설문 완료 - 결과 페이지로 이동
+    router.push({
+      name: "investmentSurveyResult",
+      query: { type: resultType.value },
+    });
   }
-}
-
-function resetSurvey() {
-  currentIndex.value = 0;
-  selected.value = null;
-  answers.value = [];
-  scores.value = [0, 0, 0, 0, 0];
-  showResult.value = false;
 }
 </script>
 


### PR DESCRIPTION
## 🔖 PR 유형
- [x] ✨ 기능 추가
- [ ] 🐛 버그 수정
- [ ] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요
- 투자조사 및 투자성향조사 결과 페이지 수정 

## 🔧 작업 내용
- 투자성향조사 결과 페이지  ui 수정 , 홈 / 완료 버튼 구분 
- 투자성향 한글 => 영어 매핑  
- 완료버튼 누를 시 백엔드 member table에  invest_type 전송  
-[크레이터] 안전형 CONSERVATIVE
[가이아]  안정추구형  STABLE
[네뷸라] 공격투자형 , AGGRESSIVE 
[루나] 위험중립형, NEUTRAL
[볼케이노] 적극투자형 GROWTH
- 
## ✅ 체크리스트
- [x] 테스트 완료(Postman, Swagger)

## 📝 기타 참고 사항
- 주의할 점, 추후 리팩토링 필요성 등

## 📎 관련 이슈
Close #이슈번호