### PR TITLE
[Feat#116] 절세 요약 api 연동

### DIFF
--- a/src/api/reprotApi.js
+++ b/src/api/reprotApi.js
@@ -1,0 +1,20 @@
+import api from "@/api";
+
+const BASE_URL = "/api/isa/reports";
+
+export default {
+  async getTaxSavingSummary() {
+    try {
+      // 백틱(`)으로 감싸야 ${BASE_URL}가 정상 동작합니다.
+      const { data } = await api.get(`${BASE_URL}/account-comparison`);
+
+      // 서버에서 Response<AccountComparisonDTO> 형태로 오는 경우
+      // 실제 데이터는 data.data 안에 있을 가능성이 높습니다.
+      console.log("getTaxSavingSummary:", data);
+      return data.data ? data.data : data; // data.data가 있으면 반환, 없으면 전체 반환
+    } catch (error) {
+      console.error("getTaxSavingSummary 실패:", error);
+      throw error;
+    }
+  },
+};

--- a/src/components/report/TaxSavingSummaryCard.vue
+++ b/src/components/report/TaxSavingSummaryCard.vue
@@ -1,0 +1,42 @@
+<template>
+  <div :class="['p-5 rounded-xl shadow-md w-full', bgColor]">
+    <div class="space-y-2">
+      <div v-if="title" class="text-base font-semibold">{{ title }}</div>
+      <div class="space-y-1 text-sm">
+        <div class="flex justify-between">
+          <span>원금</span>
+          <span class="text-black">{{ formatNumber(principal) }} 원</span>
+        </div>
+        <div class="flex justify-between">
+          <span>- 세금</span>
+          <span class="text-black">{{ formatNumber(tax) }} 원</span>
+        </div>
+
+        <!-- 총액 위 구분선 -->
+        <div class="border-t border-gray-300 my-1"></div>
+
+        <div class="flex justify-between font-semibold">
+          <span>최종</span>
+          <span :class="finalAmountColor">{{ formatNumber(finalAmount) }} 원</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+const props = defineProps({
+  title: { type: String, default: "" },
+  principal: { type: Number, required: true },
+  tax: { type: Number, required: true },
+  finalAmount: { type: Number, required: true },
+  finalAmountColor: { type: String, default: "text-black font-bold" },
+  bgColor: { type: String, default: "bg-white" },
+});
+
+// 3자리마다 콤마 표시, undefined/null 안전 처리
+const formatNumber = (num) => {
+  if (num == null || isNaN(num)) return "0";
+  return num.toLocaleString("ko-KR");
+};
+</script>

--- a/src/components/report/TaxSavingSummaryCard.vue
+++ b/src/components/report/TaxSavingSummaryCard.vue
@@ -1,5 +1,6 @@
 <template>
-  <div :class="['p-5 rounded-xl shadow-md w-full', bgColor]">
+  <div :class="['p-5 rounded-xl shadow-sm w-full', bgColor]">
+    <!-- shadow-md → shadow-sm -->
     <div class="space-y-2">
       <div v-if="title" class="text-base font-semibold">{{ title }}</div>
       <div class="space-y-1 text-sm">
@@ -34,7 +35,6 @@ const props = defineProps({
   bgColor: { type: String, default: "bg-white" },
 });
 
-// 3자리마다 콤마 표시, undefined/null 안전 처리
 const formatNumber = (num) => {
   if (num == null || isNaN(num)) return "0";
   return num.toLocaleString("ko-KR");

--- a/src/components/report/TaxSavingsSummary.vue
+++ b/src/components/report/TaxSavingsSummary.vue
@@ -21,7 +21,8 @@
     </div>
 
     <!-- 절세율 요약 카드 -->
-    <div class="p-5 rounded-xl shadow-md w-full bg-blue-50">
+    <div class="p-5 rounded-xl shadow-sm w-full bg-blue-50">
+      <!-- shadow-md → shadow-sm -->
       <div class="text-base font-semibold mb-2">절세율 요약</div>
       <div class="flex justify-between text-sm">
         <span>절세 금액</span>

--- a/src/components/report/TaxSavingsSummary.vue
+++ b/src/components/report/TaxSavingsSummary.vue
@@ -1,0 +1,61 @@
+<template>
+  <div class="flex flex-col gap-2">
+    <div class="flex gap-2">
+      <TaxSavingSummaryCard
+        title="ISA 계좌"
+        :bgColor="'bg-green-50'"
+        :principal="summary.principal"
+        :tax="summary.isaTax"
+        :finalAmount="summary.isaTotalAmount"
+        finalAmountColor="text-green-700 font-bold"
+      />
+
+      <TaxSavingSummaryCard
+        title="일반 계좌"
+        :bgColor="'bg-red-50'"
+        :principal="summary.principal"
+        :tax="summary.generalTax"
+        :finalAmount="summary.generalTotalAmount"
+        finalAmountColor="text-red-700 font-bold"
+      />
+    </div>
+
+    <!-- 절세율 요약 카드 -->
+    <div class="p-5 rounded-xl shadow-md w-full bg-blue-50">
+      <div class="text-base font-semibold mb-2">절세율 요약</div>
+      <div class="flex justify-between text-sm">
+        <span>절세 금액</span>
+        <span class="font-bold text-blue-700">{{ formatNumber(summary.taxSaved) }} 원</span>
+      </div>
+      <div class="flex justify-between text-sm">
+        <span>절세율</span>
+        <span class="font-bold text-blue-700">{{ summary.taxSavingRate }}%</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from "vue";
+import api from "@/api/reprotApi";
+import TaxSavingSummaryCard from "./TaxSavingSummaryCard.vue";
+
+const summary = ref({});
+
+const load = async () => {
+  try {
+    const res = await api.getTaxSavingSummary();
+    summary.value = res;
+  } catch (err) {
+    console.error("getTaxSavingSummary API 호출 실패", err);
+  }
+};
+
+onMounted(load);
+
+// 3자리마다 콤마 표시, undefined/null 안전 처리
+const formatNumber = (num) => {
+  if (num == null || isNaN(num)) return "0";
+  return num.toLocaleString("ko-KR");
+};
+</script>

--- a/src/views/report/ReportView.vue
+++ b/src/views/report/ReportView.vue
@@ -52,6 +52,9 @@
     <div v-else-if="activeTab === 'isa'">
       <IsaReport />
     </div>
+    <div v-if="activeTab === 'isa'" class="mt-2">
+      <TaxSavingsSummary />
+    </div>
   </DefaultLayout>
 </template>
 
@@ -63,6 +66,7 @@ import GoalAchievementChart from "@/components/report/GoalAchievementChart.vue";
 import IsaReport from "@/components/report/IsaReport.vue";
 import { ref, onMounted } from "vue";
 import api from "@/api";
+import TaxSavingsSummary from "@/components/report/TaxSavingsSummary.vue";
 
 const activeTab = ref("investment");
 const goals = ref([]);


### PR DESCRIPTION
## 🔖 PR 유형
- [ ] ✨ 기능 추가
- [ ] 🐛 버그 수정
- [ ] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요
isa 계좌와 일반 계좌의 절세를 비교하는 요약을 api연결하여 나타냅니다.

## 🔧 작업 내용
- 기본적인 카드 컴포넌트 구현
- api연동
- layout구성

## ✅ 체크리스트
- [ ] 테스트 완료(Postman, Swagger)

## 📝 기타 참고 사항
<img width="428" height="311" alt="image" src="https://github.com/user-attachments/assets/2a5c338d-359c-4628-b1b5-f61d0c23b59b" />


## 📎 관련 이슈
Close #116 